### PR TITLE
refactor(api)!: freeze the public export surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ A hardening pass ahead of 1.0. Several items are intentionally breaking now (bef
   cluster workers; request distribution is the OS's job (round-robin `SCHED_RR`).
 - **BREAKING** `req.env` / `req.ctx` / `req.cf` removed from the root `Request`; runtime
   context now lives under `req.platform`.
+- **BREAKING** Froze the public export surface. Internal machinery (the router and
+  middleware registries, response-cache store plumbing, error normalization, the OpenAPI
+  doc builder) is no longer re-exported from the package root — only the supported API is.
+  The built-in adapters consume internals via deep imports; this does not affect them.
 - Consolidated the triplicated max-body-size constant into a single `DEFAULT_MAX_BODY_SIZE`.
 - Factored a shared `WebApiRequestBase` for the Bun and Cloudflare adapters.
 - Standardized route-error detection on `isRouteError` across all adapters.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,52 @@
-export * from "@/config/serverConfig";
+// Public API surface. Everything re-exported here is the supported, semver-frozen
+// API. Internal machinery (the router and middleware registries, response-cache
+// store plumbing, error normalization, OpenAPI doc builder) is intentionally not
+// re-exported — the built-in adapters consume it via deep imports.
+
+// Server & config
+export { createServer } from "@/core/server";
+export { getConfig } from "@/config/serverConfig";
+
+// Route handlers, validation & typed responses
 export * from "@/core/defineHandler";
-export * from "@/core/openapi";
-export * from "@/core/server";
-export * from "@/core/router";
-export * from "@/core/middleware";
-export * from "@/core/errors";
+
+// Project layout
+export { getRoutesDir } from "@/core/router";
+
+// Middleware factories
+export { createCorsMiddleware } from "@/core/cors";
 export * from "@/core/rateLimit";
-export * from "@/core/responseCache";
-export * from "@/core/streaming";
-export * from "@/core/cors";
+export { createResponseCache, withCache, defaultCacheKey } from "@/core/responseCache";
+export type {
+  ResponseCacheOptions,
+  WithCacheOptions,
+  CacheEntry,
+  CacheStore,
+} from "@/core/responseCache";
+
+// Streaming & SSE
+export { parseNDJSON } from "@/core/streaming";
 export { initSSE } from "@/sse/server";
 export * from "@/sse/client";
+
+// HTTP errors
+export {
+  HTTP_STATUS,
+  createHttpError,
+  isHttpError,
+  sendError,
+  createBadRequestError,
+  createUnauthorizedError,
+  createForbiddenError,
+  createNotFoundError,
+  createMethodNotAllowedError,
+  createConflictError,
+  createValidationError,
+  createRateLimitError,
+  createInternalServerError,
+  createServiceUnavailableError,
+  createGatewayTimeoutError,
+} from "@/core/errors";
+
+// Public types (incl. the augmentation targets Locals / PlatformContext)
 export * from "@/types/index";


### PR DESCRIPTION
Stacked on #9.

## Why
The package root used `export *` from every core module, so the public API leaked internal machinery (router/middleware registries, cache store plumbing, error normalization, the OpenAPI doc builder). This trims the surface to only the supported API.

## Kept (supported API)
`createServer`, `getConfig`, `getRoutesDir`, `defineHandler` (+ types), `createCorsMiddleware`, `createRateLimit`/`createInMemoryRateLimitStore`, `createResponseCache`/`withCache`/`defaultCacheKey` (+ `CacheStore` etc.), `parseNDJSON`, `initSSE`, `createSSEClient`, all error constructors + `sendError`/`isHttpError`/`HTTP_STATUS`, and all public types (incl. `Locals`/`PlatformContext`).

## Removed from the root (internal)
router internals (`router`, `resetRouter`, `getRouterStats`, `setVerboseLogging`, `registerRoutes`, `loadRoutes`, `findRoute`, `isRouteError`), the whole middleware registry (`addMiddleware`, `runMiddlewares`, `registerMiddlewareConfig`, …), cache plumbing (`createStore`, `interceptResponse`, `replayEntry`), `registerCorsConfig`, `buildOpenApiDoc`, `normalizeError`, `logError`, `defaultConfig`.

## Safety
- No internal code imports through the barrel — adapters use deep `@/core/*` imports — so the build is unaffected.
- Verified the built `index.d.ts`: **0** internal symbols remain; all public symbols present.
- typecheck + build + full suite green.